### PR TITLE
Add setting to enable/disable shortcuts

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -17,6 +17,8 @@ local function icon(s, x, y)
     }
 end
 
+local add_shortcuts = settings.startup["BlueprintExtensions_add-shortcuts"].value
+
 for name, action in pairs(actions) do
     if action.key_sequence then
         data:extend{ {
@@ -32,23 +34,26 @@ for name, action in pairs(actions) do
         sprite.type = "sprite"
         sprite.name = name
 
-        data:extend {
-            sprite,
-            {
-                name = name,
-                type = "shortcut",
-                localised_name = { "controls." .. name },
-                associated_control_input = (action.key_sequence and name or nil),
-                action = "lua",
-                toggleable = action.toggleable or false,
-                icon = icon(32, action.icon, 1),
-                disabled_icon = icon(32, action.icon, 0),
-                small_icon = icon(24, action.icon, 1),
-                disabled_small_icon = icon(24, action.icon, 0),
-                style = action.shortcut_style,
-                order = "b[blueprints]-x[bpex]-" .. action.order
+        data:extend{sprite}
+
+        if add_shortcuts then
+            data:extend{
+                {
+                    name = name,
+                    type = "shortcut",
+                    localised_name = { "controls." .. name },
+                    associated_control_input = (action.key_sequence and name or nil),
+                    action = "lua",
+                    toggleable = action.toggleable or false,
+                    icon = icon(32, action.icon, 1),
+                    disabled_icon = icon(32, action.icon, 0),
+                    small_icon = icon(24, action.icon, 1),
+                    disabled_small_icon = icon(24, action.icon, 0),
+                    style = action.shortcut_style,
+                    order = "b[blueprints]-x[bpex]-" .. action.order
+                }
             }
-        }
+        end
     end
 end
 

--- a/gui.lua
+++ b/gui.lua
@@ -68,9 +68,11 @@ function GUI.update_visibility(player, force)
         flow.visible = enabled
     end
 
-    for name, action in pairs(actions) do
-        if action.icon then
-            player.set_shortcut_available(name, enabled)
+    if settings.startup["BlueprintExtensions_add-shortcuts"].value then
+        for name, action in pairs(actions) do
+            if action.icon then
+                player.set_shortcut_available(name, enabled)
+            end
         end
     end
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -41,6 +41,8 @@ BlueprintExtensions_wireswap=Make red circuit wires green and vice versa.
 
 
 [mod-setting-name]
+BlueprintExtensions_add-shortcuts=Add shortcuts
+
 BlueprintExtensions_cardinal-center=Snap to edge centers blueprint first
 BlueprintExtensions_horizontal-invert=Invert horizontal axis when snapping
 BlueprintExtensions_vertical-invert=Invert vertical axis when snapping
@@ -60,6 +62,7 @@ BlueprintExtensions_landfill-mode=Action upon landfilling a blueprint
 
 
 [mod-setting-description]
+BlueprintExtensions_add-shortcuts=Add buttons to the shortcut bar as well as the side menu.
 BlueprintExtensions_cardinal-center=ON: Snapping to an edge centers the blueprint on the opposite axis.\nOFF: Snapping to an edge does not move the blueprint on the opposite axis.\n\nSetting this to OFF means that snapping to North + snapping to East is the same effect as snapping to Northeast, useful if you have limited keybind space (e.g. no numpad).
 BlueprintExtensions_horizontal-invert=Snap to East/West moves that edge of the blueprint to under the cursor rather than aligning the blueprint to that edge.
 BlueprintExtensions_vertical-invert=Snap to North/South moves that edge of the blueprint to under the cursor rather than aligning the blueprint to that edge.

--- a/settings.lua
+++ b/settings.lua
@@ -1,5 +1,12 @@
 data:extend{
     {
+        type = "bool-setting",
+        name = "BlueprintExtensions_add-shortcuts",
+        setting_type = "startup",
+        order = 100,
+        default_value = true
+    },
+    {
         type = "string-setting",
         name = "BlueprintExtensions_version-increment",
         setting_type = "runtime-per-user",
@@ -85,7 +92,7 @@ data:extend{
         setting_type = "runtime-per-user",
         order = 504,
         default_value = true,
-    },
+    }
 }
 
 


### PR DESCRIPTION
I love Blueprint Extensions, it is a great mod. However, I do not like the blueprinting tools to be on my shortcut bar. I never use them there, instead using the original side menu. Even though you can remove them from the actual bar, they're always in the re-ordering menu and can't be gotten rid of entirely.

So I added a startup option to disable the shortcuts entirely. With this, the side menu is still there and usable, and the shortcut bar is clutter-free.

Thanks again for making the mod, it's one of my favorites and I can't live without it!